### PR TITLE
enable-config-nullability

### DIFF
--- a/BetterJoy/Config/Config.cs
+++ b/BetterJoy/Config/Config.cs
@@ -29,7 +29,6 @@ public abstract class Config
             case Enum:
                 setting = (T)Enum.Parse(typeof(T), value, true);
                 break;
-            case string:
             case IConvertible:
                 setting = (T)Convert.ChangeType(value, typeof(T));
                 break;
@@ -42,13 +41,14 @@ public abstract class Config
         }
     }
 
-    private void ParseArrayAs<T>(string value, T[] settings) //Note, even though the array is passed by value, edits to it persist to the original
+    private void ParseArrayAs<T>(string value, T[] settings)
     {
         var tokens = value.Split(',', StringSplitOptions.TrimEntries);
 
         for (int i = 0; i < settings.Length; i++)
         {
-            ParseAs(i < tokens.Length ? tokens[i] : tokens[^1], ref settings[i]);
+            var currentToken = i < tokens.Length ? tokens[i] : tokens[^1];
+            ParseAs(currentToken, ref settings[i]);
         }
     }
 


### PR DESCRIPTION
Added nullability to the config object. I also modified the way the type resolution worked in the parsing functions. I also think I fixed a bug where we were checking if a type OBJECT was an IConvertible (which it never is since type does not implement IConvertible).

This version is a little less straightforward since we're not passing the array as a ref, but I confirmed it does work. Left a comment to hopefully keep things clear. 